### PR TITLE
Use AWS registry instead of Dockerhub

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ python:
 
 install:
   # Install conda
-  - wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
+  - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
   - bash miniconda.sh -b -p $HOME/miniconda
   - export PATH="$HOME/miniconda/bin:$PATH"
   - python -c 'import os,sys,fcntl; flags = fcntl.fcntl(sys.stdout, fcntl.F_GETFL); fcntl.fcntl(sys.stdout, fcntl.F_SETFL, flags&~os.O_NONBLOCK);'

--- a/Makefile
+++ b/Makefile
@@ -3,21 +3,24 @@ NEW_RELIC_TOKEN := `cat ~/.newrelic-$(VERSION)`
 
 dist-build:
 	cd distributed && \
-	docker build -t opensourcepolicycenter/distributed:$(TAG) ./ --build-arg PUF_TOKEN=$(OSPC_ANACONDA_TOKEN) && \
-	docker build --no-cache --build-arg TAG=$(TAG) -t opensourcepolicycenter/flask:$(TAG) --file Dockerfile.flask ./ && \
-	docker build --no-cache --build-arg TAG=$(TAG) -t opensourcepolicycenter/celery:$(TAG) --file Dockerfile.celery ./
+	docker build -t distributed:$(TAG) ./ --build-arg PUF_TOKEN=$(OSPC_ANACONDA_TOKEN) && \
+	docker build --no-cache --build-arg TAG=$(TAG) -t flask:$(TAG) --file Dockerfile.flask ./ && \
+	docker build --no-cache --build-arg TAG=$(TAG) -t celery:$(TAG) --file Dockerfile.celery ./
 
 dist-build-local:
 	cd distributed && \
-	docker build -t opensourcepolicycenter/distributed:$(TAG) ./ --build-arg PUF_TOKEN=$(OSPC_ANACONDA_TOKEN) --file Dockerfile.local && \
-	docker build --no-cache --build-arg TAG=$(TAG) -t opensourcepolicycenter/flask:$(TAG) --file Dockerfile.flask ./ && \
-	docker build --no-cache --build-arg TAG=$(TAG) -t opensourcepolicycenter/celery:$(TAG) --file Dockerfile.celery ./
+	docker build -t distributed:$(TAG) ./ --build-arg PUF_TOKEN=$(OSPC_ANACONDA_TOKEN) --file Dockerfile.local && \
+	docker build --no-cache --build-arg TAG=$(TAG) -t flask:$(TAG) --file Dockerfile.flask ./ && \
+	docker build --no-cache --build-arg TAG=$(TAG) -t celery:$(TAG) --file Dockerfile.celery ./
 
 dist-push:
 	cd distributed && \
-	docker push opensourcepolicycenter/distributed:$(TAG) && \
-	docker push opensourcepolicycenter/flask:$(TAG) && \
-	docker push opensourcepolicycenter/celery:$(TAG)
+	docker tag distributed:$(TAG) $(AWS_ACCOUNT_ID).dkr.ecr.$(AWS_REGION).amazonaws.com/distributed:$(TAG) && \
+	docker tag distributed:$(TAG) $(AWS_ACCOUNT_ID).dkr.ecr.$(AWS_REGION).amazonaws.com/flask:$(TAG) && \
+	docker tag distributed:$(TAG) $(AWS_ACCOUNT_ID).dkr.ecr.$(AWS_REGION).amazonaws.com/celery:$(TAG) && \
+	docker push $(AWS_ACCOUNT_ID).dkr.ecr.$(AWS_REGION).amazonaws.com/distributed:$(TAG) && \
+	docker push $(AWS_ACCOUNT_ID).dkr.ecr.$(AWS_REGION).amazonaws.com/flask:$(TAG) && \
+	docker push $(AWS_ACCOUNT_ID).dkr.ecr.$(AWS_REGION).amazonaws.com/celery:$(TAG)
 
 dist-test:
 	cd distributed && \

--- a/distributed/docker-compose.yml
+++ b/distributed/docker-compose.yml
@@ -1,14 +1,14 @@
 version: '3'
 services:
   flask:
-    image: "opensourcepolicycenter/flask:${TAG}"
+    image: "$(REPO)/flask:${TAG}"
     ports:
       - 5050:5050
     depends_on:
       - redis
       - celery
   celery:
-    image: "opensourcepolicycenter/celery:${TAG}"
+    image: "$(REPO)/celery:${TAG}"
     depends_on:
       - redis
   redis:

--- a/python_env_build.sh
+++ b/python_env_build.sh
@@ -1,10 +1,12 @@
 echo 'creating environment pb_env and installing conda packages'
-conda env create
-echo 'successfull created env: pb_env'
+conda create -n pb_env python=3.6 --yes
+echo 'successfully created env: pb_env'
 
 echo 'activating env: pb_env'
 source activate pb_env
+echo 'installing conda packages'
+conda install -c ospc -c anaconda --file conda-requirements.txt --yes
 
 echo 'pip installing remaining requirements'
-pip install -r requirements.txt
-pip install -r requirements_dev.txt
+pip install -qr requirements.txt
+pip install -qr requirements_dev.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,7 @@ yolk==0.4.3
 django-ipware
 requests_mock
 boto
-django-storages
+django-storages==1.6.3
 django-htmlmin
 pyparsing
 python-dateutil

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,4 +1,3 @@
-django-debug-toolbar==1.2.1
 ipdb==0.8
 ipython==2.2.0
 yolk==0.4.3


### PR DESCRIPTION
This PR migrates PolicyBrain from Dockerhub to AWS Container Registry. Except for the webapp, we do most of our deployment with AWS.  Moving to the AWS CR consolidates our tech to one place.