### PR TITLE
Add subscribed landing page

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -4,6 +4,19 @@ Go
 [here](https://github.com/OpenSourcePolicyCenter/PolicyBrain/pulls?q=is%3Apr+is%3Aclosed)
 for a complete commit history.
 
+Release 1.7.2 on 2018-10-31
+----------------------------
+**Major Changes**
+- None
+
+**Minor Changes**
+- [#931](https://github.com/ospc-org/ospc.org/pull/937) - Use conda 'defaults' channel instead of 'anaconda' - Hank Doupe
+- [#938](https://github.com/ospc-org/ospc.org/pull/938) - Add subscribed landing page - Hank Doupe
+
+**Bug Fixes**
+- None
+
+
 Release 1.7.1 on 2018-08-30
 ----------------------------
 **Major Changes**

--- a/templates/pages/thanks-for-subscribing.html
+++ b/templates/pages/thanks-for-subscribing.html
@@ -1,0 +1,12 @@
+{% extends 'pages/home.html' %}
+{% block content %}
+<div class="container">
+  <div class="row">
+    <div class="columns col-md-12">
+      <h2>Thank you for joining our mailing list!</h2>
+      <p>Thank you for signing up for the OSPC newsletter. This is the best way to stay up to date on the latest news from the Open Source Policy Center.</p>
+    </div>
+  </div>
+</div>
+{% endblock %}
+

--- a/webapp/apps/pages/tests/test_views.py
+++ b/webapp/apps/pages/tests/test_views.py
@@ -1,7 +1,7 @@
 from django.test import TestCase
 
 
-class PagesViewsTestCase(TestCase):
+class PageViewsTests(TestCase):
     def test_about(self):
         resp = self.client.get('/about/')
         self.assertEqual(resp.status_code, 200)
@@ -14,6 +14,6 @@ class PagesViewsTestCase(TestCase):
         resp = self.client.get('/news/')
         self.assertEqual(resp.status_code, 302)
 
-    def test_apps(self):
-        resp = self.client.get('/apps/')
+    def test_subscribed(self):
+        resp = self.client.get('/subscribed/')
         self.assertEqual(resp.status_code, 200)

--- a/webapp/apps/pages/urls.py
+++ b/webapp/apps/pages/urls.py
@@ -2,12 +2,14 @@ from django.conf.urls import patterns, include, url
 
 from .views import (homepage, aboutpage, newspage, gallerypage, hellopage,
                    embedpage, widgetpage, newsdetailpage,
-                   apps_landing_page, border_adjustment_plot, docspage, gettingstartedpage)
+                   apps_landing_page, border_adjustment_plot, docspage,
+                   gettingstartedpage, subscribed)
 
 urlpatterns = [
     url(r'^$', homepage, name='home'), # url(r'^apps/$', apps_landing_page, name='apps'),
     url(r'^about/$', aboutpage, name='about'),
     url(r'^getting-started/$', gettingstartedpage, name='gettingstartedpage'),
+    url(r'^subscribed/$', subscribed, name='subscribed'),
     url(r'^hello/$', hellopage, name='hello'),
     url(r'^gallery/$', gallerypage, name='gallery'),
     url(r'^news/$', newspage, name='news'),

--- a/webapp/apps/pages/views.py
+++ b/webapp/apps/pages/views.py
@@ -36,6 +36,11 @@ def subscribeform(request):
         subscribeform = SubscribeForm()
     return subscribeform
 
+
+def subscribed(request):
+    return render(request, 'pages/thanks-for-subscribing.html')
+
+
 def check_email(request):
     return render(request, 'register/please-check-email.html', {})
 

--- a/webapp/settings.py
+++ b/webapp/settings.py
@@ -58,7 +58,7 @@ TEMPLATES = [
 ]
 
 
-WEBAPP_VERSION = "1.7.0"
+WEBAPP_VERSION = "1.7.2"
 
 # Application definition
 


### PR DESCRIPTION
Adds a landing page for users who have just subscribed to the mailing list. In the first PR (#936), I started to remove the unused registration app in addition to adding the landing page. However, until I know how the new email form will work it's difficult to know how to handle the POST action when users subscribe to the list. I won't know that until I have the form, but the AEI team developing the form needs a landing page for testing. Therefore, I will simply add the landing page in this PR. The page looks like:

![screen shot 2018-10-31 at 2 18 03 pm](https://user-images.githubusercontent.com/9206065/47811359-f2abc900-dd1b-11e8-859d-f4abd40b5618.png)


cc @Peter-Metz @MattHJensen 