### PR TITLE
Update to Tax-Calculator 0.22.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-OSPC_ANACONDA_TOKEN := `cat ~/.ospc_anaconda_token`
+OSPC_PW := `cat ~/.ospc_anaconda_token`
 NEW_RELIC_TOKEN := `cat ~/.newrelic-$(VERSION)`
 
 dist-build:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-OSPC_PW := `cat ~/.ospc_anaconda_token`
+OSPC_ANACONDA_TOKEN := `cat ~/.ospc_anaconda_token`
 NEW_RELIC_TOKEN := `cat ~/.newrelic-$(VERSION)`
 
 dist-build:

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -4,6 +4,18 @@ Go
 [here](https://github.com/OpenSourcePolicyCenter/PolicyBrain/pulls?q=is%3Apr+is%3Aclosed)
 for a complete commit history.
 
+Release 1.7.4 on 2018-11-06
+----------------------------
+**Major Changes**
+- None
+
+**Minor Changes**
+- [#939](https://github.com/ospc-org/ospc.org/pull/939) - Update to Tax-Calculator 0.22.2 - Hank Doupe
+
+**Bug Fixes**
+- None
+
+
 Release 1.7.3 on 2018-11-02
 ----------------------------
 **Major Changes**

--- a/conda-requirements.txt
+++ b/conda-requirements.txt
@@ -1,5 +1,5 @@
 nomkl
-taxcalc==0.20.1
+taxcalc==0.22.2
 btax==0.2.2
 ogusa==0.5.11
 numba>=0.33.0

--- a/distributed/Dockerfile
+++ b/distributed/Dockerfile
@@ -13,7 +13,7 @@ RUN conda config --add channels ospc
 RUN conda config --add channels ospc/label/dev
 RUN conda config --append channels conda-forge
 
-RUN conda install numpy>=1.12.1 pandas>=0.23.0 taxcalc=0.22.2 \
+RUN conda install python=3.6 numpy>=1.12.1 pandas>=0.23.0 taxcalc=0.22.2 \
     btax=0.2.2 ogusa=0.5.11 matplotlib>=3.0.1 numba six bokeh>=0.12.7 mock xlrd \
     sphinx nomkl
 
@@ -28,8 +28,7 @@ ARG PUF_TOKEN
 RUN if [ -z ${PUF_TOKEN+x} ]; \
         then echo PUF token not specified; \
         else echo getting and writing PUF file && \
-            conda config --add channels https://conda.anaconda.org/t/${PUF_TOKEN}/opensourcepolicycenter && \
-            conda install taxpuf -c opensourcepolicycenter && \
+            conda install taxpuf matplotlib>=3.0.1 -c https://conda.anaconda.org/t/$PUF_TOKEN/opensourcepolicycenter && \
             write-latest-taxpuf; \
             gunzip -k puf.csv.gz; \
         fi

--- a/distributed/Dockerfile
+++ b/distributed/Dockerfile
@@ -8,12 +8,13 @@ COPY requirements.txt home/distributed
 
 WORKDIR /home/distributed
 
+RUN conda update conda
 RUN conda config --add channels ospc
 RUN conda config --add channels ospc/label/dev
 RUN conda config --append channels conda-forge
 
-RUN conda install numpy>=1.12.1 pandas>=0.23.0 taxcalc=0.20.1 \
-    btax=0.2.2 ogusa=0.5.11 matplotlib numba six bokeh>=0.12.7 mock xlrd \
+RUN conda install numpy>=1.12.1 pandas>=0.23.0 taxcalc=0.22.2 \
+    btax=0.2.2 ogusa=0.5.11 matplotlib>=3.0.1 numba six bokeh>=0.12.7 mock xlrd \
     sphinx nomkl
 
 RUN pip install -r requirements.txt
@@ -27,7 +28,8 @@ ARG PUF_TOKEN
 RUN if [ -z ${PUF_TOKEN+x} ]; \
         then echo PUF token not specified; \
         else echo getting and writing PUF file && \
-            conda install taxpuf -c https://conda.anaconda.org/t/$PUF_TOKEN/opensourcepolicycenter && \
+            conda config --add channels https://conda.anaconda.org/t/${PUF_TOKEN}/opensourcepolicycenter && \
+            conda install taxpuf -c opensourcepolicycenter && \
             write-latest-taxpuf; \
             gunzip -k puf.csv.gz; \
         fi

--- a/distributed/Dockerfile
+++ b/distributed/Dockerfile
@@ -29,6 +29,6 @@ RUN if [ -z ${PUF_TOKEN+x} ]; \
         then echo PUF token not specified; \
         else echo getting and writing PUF file && \
             conda install taxpuf matplotlib>=3.0.1 -c https://conda.anaconda.org/t/$PUF_TOKEN/opensourcepolicycenter && \
-            write-latest-taxpuf; \
+            write-latest-taxpuf && \
             gunzip -k puf.csv.gz; \
         fi

--- a/webapp/apps/conftest.py
+++ b/webapp/apps/conftest.py
@@ -247,18 +247,14 @@ def errors_warnings_exp_read_json_reform():
     _errors_warnings_exp_read_json_reform = {
         2018: {
             '_FICA_ss_trt': [-1.0],
-            '_ID_BenefitSurtax_Switch': [[True, True, True, True,
-                                          True, True, False]],
-            '_STD': [[10000.0, 24000.0, 12000.0, 20000.0, 24000.0]]
-        },
+            '_ID_BenefitSurtax_Switch': [[True, True, True, True, True, True, False]],
+            '_STD': [[12000.0, 24000.0, 12000.0, 20000.0, 24000.0]]},
         2019: {
             '_FICA_ss_trt': [0.1],
-            '_II_brk4': [[500.0, 321268.5, 160634.25, 160634.25, 321268.5]]
-        },
+            '_II_brk4': [[500.0, 321268.5, 160634.25, 160634.25, 321268.5]]},
         2020: {
-            '_STD': [[10409.1, 24981.84, 12490.92, 150.0, 24981.84]]
-        }
-    }
+            '_ID_Medical_frt': [0.05],
+            '_STD': [[12490.92, 24981.84, 12490.92, 150.0, 24981.84]]}}
     return _errors_warnings_exp_read_json_reform
 
 

--- a/webapp/apps/dynamic/compute.py
+++ b/webapp/apps/dynamic/compute.py
@@ -19,7 +19,7 @@ DROPQ_WORKERS = dropq_workers.split(",")
 ENFORCE_REMOTE_VERSION_CHECK = os.environ.get('ENFORCE_VERSION', 'False') == 'True'
 TIMEOUT_IN_SECONDS = 1.0
 MAX_ATTEMPTS_SUBMIT_JOB = 20
-AGG_ROW_NAMES = taxcalc.tbi_utils.AGGR_ROW_NAMES
+AGG_ROW_NAMES = taxcalc.tbi.AGG_ROW_NAMES
 GDP_ELAST_ROW_NAMES = taxcalc.tbi.GDP_ELAST_ROW_NAMES
 ogusa_workers = os.environ.get('OGUSA_WORKERS', '')
 OGUSA_WORKERS = ogusa_workers.split(",")

--- a/webapp/apps/taxbrain/compute.py
+++ b/webapp/apps/taxbrain/compute.py
@@ -24,7 +24,7 @@ DROPQ_SMALL_URL = "/dropq_small_start_job"
 ENFORCE_REMOTE_VERSION_CHECK = os.environ.get('ENFORCE_VERSION', 'False') == 'True'
 TIMEOUT_IN_SECONDS = 1.0
 MAX_ATTEMPTS_SUBMIT_JOB = 20
-AGG_ROW_NAMES = taxcalc.tbi_utils.AGGR_ROW_NAMES
+AGG_ROW_NAMES = taxcalc.tbi.AGG_ROW_NAMES
 GDP_ELAST_ROW_NAMES = taxcalc.tbi.GDP_ELAST_ROW_NAMES
 BYTES_HEADER = {'Content-Type': 'application/octet-stream'}
 

--- a/webapp/apps/taxbrain/helpers.py
+++ b/webapp/apps/taxbrain/helpers.py
@@ -214,7 +214,7 @@ INPUTS_META = ('has_errors', 'csrfmiddlewaretoken', 'start_year',
 #
 TAXCALC_RESULTS_START_YEAR = START_YEAR
 TAXCALC_RESULTS_MTABLE_COL_LABELS = taxcalc.DIST_TABLE_LABELS[:]
-TAXCALC_RESULTS_DFTABLE_COL_LABELS = taxcalc.DIFF_TABLE_LABELS[:-2]
+TAXCALC_RESULTS_DFTABLE_COL_LABELS = taxcalc.DIFF_TABLE_LABELS[:]
 TAXCALC_RESULTS_MTABLE_COL_FORMATS = [
     #   divisor,   unit,   decimals
     [      1000,      None, 0], # 'Returns',

--- a/webapp/apps/taxbrain/helpers.py
+++ b/webapp/apps/taxbrain/helpers.py
@@ -317,7 +317,7 @@ TAXCALC_RESULTS_TABLE_LABELS = {
     'aggr_2': 'Total Liabilities Reform by Calendar Year'
 }
 
-AGG_ROW_NAMES = taxcalc.tbi_utils.AGGR_ROW_NAMES
+AGG_ROW_NAMES = taxcalc.tbi.AGG_ROW_NAMES
 TAXCALC_RESULTS_TOTAL_ROW_KEY_LABELS = {
     'ind_tax':'Individual Income Tax Liability Change',
     'payroll_tax':'Payroll Tax Liability Change',

--- a/webapp/apps/taxbrain/tests/test_views.py
+++ b/webapp/apps/taxbrain/tests/test_views.py
@@ -415,7 +415,7 @@ class TestTaxBrainViews(object):
         data.pop('start_year')
         data.pop('data_source')
         url = '/taxbrain/?start_year={0}&data_source={1}'.format(START_YEAR, 'PUF')
-        data['STD_3'] = ['1000']
+        data['STD_3'] = ['-1000']
         response = CLIENT.post(url, data)
 
         assert response.status_code == 200
@@ -631,7 +631,7 @@ class TestTaxBrainViews(object):
         assert response.context['has_errors'] is True
         assert response.context['start_year'] == str(START_YEAR)
         assert response.context['data_source'] == data_source
-        assert any(['_STD_0' in msg and '2023' in msg
+        assert any(['_ID_Medical_frt' in msg and '2020' in msg
                     for msg in response.context['errors']])
 
         # get most recent object
@@ -651,7 +651,7 @@ class TestTaxBrainViews(object):
 
         truth_mods = {
             2020: {
-                "_STD":  [[1000, 24981.84, 12490.92, 18736.38, 24981.84]]
+                "_ID_Medical_frt":  [0.05]
             }
         }
         check_posted_params(result['tb_dropq_compute'], truth_mods, START_YEAR,
@@ -686,7 +686,7 @@ class TestTaxBrainViews(object):
         assert response.context['has_errors'] is True
         assert response.context['data_source'] == data_source
         assert response.context['start_year'] == str(start_year)
-        assert any(['_STD_0' in msg and '2023' in msg
+        assert any(['_ID_Medical_frt' in msg and '2020' in msg
                     for msg in response.context['errors']])
 
         # get most recent object

--- a/webapp/apps/test_assets/errors_warnings_json_reform.json
+++ b/webapp/apps/test_assets/errors_warnings_json_reform.json
@@ -4,7 +4,7 @@
     "_ID_BenefitSurtax_Switch_charity": {"2018": [false]},
     "_STD_headhousehold": {"2018": [20000.0], "2020": [150.0]},
     "_FICA_ss_trt": {"2018": [-1.0], "2019": [0.1]},
-    "_STD_single": {"2018": [10000.0]},
+    "_ID_Medical_frt": {"2020": [0.05]},
     "_II_brk4_single": {"2019": [500.0]}
     }
 }

--- a/webapp/apps/test_assets/exp_errors_warnings_policy.json
+++ b/webapp/apps/test_assets/exp_errors_warnings_policy.json
@@ -7,29 +7,41 @@
             "II_brk4_0": {
                 "2019": "ERROR: _II_brk4_0 value 500.0 < min value 84141.75 for _II_brk3_0 for 2019",
                 "2020": "ERROR: _II_brk4_0 value 510.3 < min value 85875.07 for _II_brk3_0 for 2020",
-                "2021": "ERROR: _II_brk4_0 value 521.17 < min value 87704.21 for _II_brk3_0 for 2021",
+                "2021": "ERROR: _II_brk4_0 value 521.12 < min value 87704.21 for _II_brk3_0 for 2021",
                 "2022": "ERROR: _II_brk4_0 value 532.53 < min value 89616.16 for _II_brk3_0 for 2022",
                 "2023": "ERROR: _II_brk4_0 value 543.82 < min value 91516.02 for _II_brk3_0 for 2023",
                 "2024": "ERROR: _II_brk4_0 value 555.51 < min value 93483.61 for _II_brk3_0 for 2024",
-                "2025": "ERROR: _II_brk4_0 value 567.34 < min value 95474.81 for _II_brk3_0 for 2025",
-                "2026": "ERROR: _II_brk4_0 value 579.42 < min value 110791.0 for _II_brk3_0 for 2026",
-                "2027": "ERROR: _II_brk4_0 value 591.88 < min value 113173.01 for _II_brk3_0 for 2027"
+                "2025": "ERROR: _II_brk4_0 value 567.29 < min value 95474.81 for _II_brk3_0 for 2025",
+                "2026": "ERROR: _II_brk4_0 value 579.43 < min value 110791.0 for _II_brk3_0 for 2026",
+                "2027": "ERROR: _II_brk4_0 value 591.83 < min value 113161.93 for _II_brk3_0 for 2027"
             }
         },
         "warnings": {
-            "STD_3": {
-                "2020": "WARNING: _STD_3 value 150.0 < min value 9834.0 for 2020",
-                "2021": "WARNING: _STD_3 value 153.2 < min value 10045.0 for 2021",
-                "2022": "WARNING: _STD_3 value 156.54 < min value 10266.0 for 2022",
-                "2023": "WARNING: _STD_3 value 159.86 < min value 10486.0 for 2023",
-                "2024": "WARNING: _STD_3 value 163.3 < min value 10714.0 for 2024",
-                "2025": "WARNING: _STD_3 value 166.78 < min value 10944.0 for 2025",
-                "2026": "WARNING: _STD_3 value 170.33 < min value 11179.0 for 2026",
-                "2027": "WARNING: _STD_3 value 173.99 < min value 11422.0 for 2027"
+            "ID_Medical_frt": {
+                "2020": "WARNING: _ID_Medical_frt value 0.05 < min value 0.075 for 2020",
+                "2021": "WARNING: _ID_Medical_frt value 0.05 < min value 0.075 for 2021",
+                "2022": "WARNING: _ID_Medical_frt value 0.05 < min value 0.075 for 2022",
+                "2023": "WARNING: _ID_Medical_frt value 0.05 < min value 0.075 for 2023",
+                "2024": "WARNING: _ID_Medical_frt value 0.05 < min value 0.075 for 2024",
+                "2025": "WARNING: _ID_Medical_frt value 0.05 < min value 0.075 for 2025",
+                "2026": "WARNING: _ID_Medical_frt value 0.05 < min value 0.075 for 2026",
+                "2027": "WARNING: _ID_Medical_frt value 0.05 < min value 0.075 for 2027"
             }
         }
     },
     "behavior": {
+        "errors": {},
+        "warnings": {}
+    },
+    "consumption": {
+        "errors": {},
+        "warnings": {}
+    },
+    "growdiff_baseline": {
+        "errors": {},
+        "warnings": {}
+    },
+    "growdiff_response": {
         "errors": {},
         "warnings": {}
     }

--- a/webapp/apps/test_assets/test_param_formatters.py
+++ b/webapp/apps/test_assets/test_param_formatters.py
@@ -251,6 +251,8 @@ def test_read_json_reform(request, _test_reform, _test_assump,
         test_assump,
         use_puf_not_cps=True
     )
+    print(json.dumps(act_reform, indent=4))
+    print(json.dumps(exp_reform, indent=4))
     print(json.dumps(act_errors_warnings, indent=4))
     print(json.dumps(exp_errors_warnings, indent=4))
     np.testing.assert_equal(act_reform, exp_reform)

--- a/webapp/apps/test_assets/warning_reform.json
+++ b/webapp/apps/test_assets/warning_reform.json
@@ -1,6 +1,6 @@
 // throws warning but not error
 {
     "policy": {
-        "_STD_single": {"2020": [1000]}
+        "_ID_Medical_frt": {"2020": [0.05]}
     }
 }

--- a/webapp/settings.py
+++ b/webapp/settings.py
@@ -58,7 +58,7 @@ TEMPLATES = [
 ]
 
 
-WEBAPP_VERSION = "1.7.3"
+WEBAPP_VERSION = "1.7.4"
 
 # Application definition
 


### PR DESCRIPTION
This PR updates PolicyBrain to Tax-Calculator 0.22.2. I hope to resolve https://github.com/ospc-org/ospc.org/issues/770 with this PR, too.

Everything looks good with the update except that there's an issue installing `taxpuf`. I'm going to keep tinkering with that and then take a look at resolving #770.

cc @martinholmer @MattHJensen 