### PR TITLE
Add marketo email form

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -4,6 +4,18 @@ Go
 [here](https://github.com/OpenSourcePolicyCenter/PolicyBrain/pulls?q=is%3Apr+is%3Aclosed)
 for a complete commit history.
 
+Release 1.7.3 on 2018-11-02
+----------------------------
+**Major Changes**
+- None
+
+**Minor Changes**
+- [#940](https://github.com/ospc-org/ospc.org/pull/940) - Add marketo email form #940 - Hank Doupe
+
+**Bug Fixes**
+- None
+
+
 Release 1.7.2 on 2018-10-31
 ----------------------------
 **Major Changes**

--- a/templates/pages/home.html
+++ b/templates/pages/home.html
@@ -144,6 +144,24 @@
   {% block extrajs %}
 
   {% endblock %}
+  <script>
+      MktoForms2.whenReady(function (form) {
+         //listen for the validate event
+          form.onValidate(function() {
+              // Get the values
+              var vals = form.vals();
+              //Check if the honeypot field is empty
+              if (vals.honeypot == "") {
+                  // Not a spam bot! Submit the form
+                  form.submittable(true);
+              }
+              else {
+                 // This is a spam bot! Don't submit the form
+                 form.submittable(false);
+              }
+          });
+      });
+  </script>
 
   </body>
 </html>

--- a/templates/pages/home.html
+++ b/templates/pages/home.html
@@ -144,24 +144,6 @@
   {% block extrajs %}
 
   {% endblock %}
-  <script>
-      MktoForms2.whenReady(function (form) {
-         //listen for the validate event
-          form.onValidate(function() {
-              // Get the values
-              var vals = form.vals();
-              //Check if the honeypot field is empty
-              if (vals.honeypot == "") {
-                  // Not a spam bot! Submit the form
-                  form.submittable(true);
-              }
-              else {
-                 // This is a spam bot! Don't submit the form
-                 form.submittable(false);
-              }
-          });
-      });
-  </script>
 
   </body>
 </html>

--- a/templates/pages/home_content.html
+++ b/templates/pages/home_content.html
@@ -70,9 +70,11 @@
     </div>
   </section>
 
-  <script src="//app-sj19.marketo.com/js/forms2/js/forms2.min.js"></script>
-  <form id="mktoForm_1179"></form>
-  <script>MktoForms2.loadForm("//app-sj19.marketo.com", "475-PBQ-971", 1179);</script>
+  <div style="margin-bottom:20px;">
+    <script src="//hello.aei.org/js/forms2/js/forms2.min.js"></script>
+    <form id="mktoForm_1179"></form>
+    <script>MktoForms2.loadForm("//app-sj19.marketo.com", "475-PBQ-971", 1179);</script>
+  </div>
 
   <div class="container">
     <section class="contribute">

--- a/templates/pages/home_content.html
+++ b/templates/pages/home_content.html
@@ -72,7 +72,7 @@
 
   <div style="margin-bottom:20px;">
     <script src="//hello.aei.org/js/forms2/js/forms2.min.js"></script>
-    <form id="mktoForm_1179"></form>
+    <form style="margin-left: auto;margin-right: auto;" id="mktoForm_1179"></form>
     <script>MktoForms2.loadForm("//app-sj19.marketo.com", "475-PBQ-971", 1179);</script>
   </div>
 

--- a/templates/pages/home_content.html
+++ b/templates/pages/home_content.html
@@ -70,25 +70,9 @@
     </div>
   </section>
 
-  <div class="container">
-    <section class="join">
-      <h2>Join the community</h2>
-      <div class="input-container">
-        <div class="input-group">
-          <form action="{% url 'home' %}" method="post">{% csrf_token %}
-          <span class="input-group-btn">
-            {{ email_form.email }}
-            {{ email_form.email.errors }}
-            <input type="submit" class="btn btn-join" value="Sign Up"/>
-          </span>
-          </form>
-          <script>
-
-          </script>
-        </div>
-      </div>
-    </section>
-  </div>
+  <script src="//app-sj19.marketo.com/js/forms2/js/forms2.min.js"></script>
+  <form id="mktoForm_1179"></form>
+  <script>MktoForms2.loadForm("//app-sj19.marketo.com", "475-PBQ-971", 1179);</script>
 
   <div class="container">
     <section class="contribute">
@@ -210,4 +194,5 @@
     </div>
   </section>
   <div class="push"></div>
+
 {% endblock  %}

--- a/webapp/settings.py
+++ b/webapp/settings.py
@@ -58,7 +58,7 @@ TEMPLATES = [
 ]
 
 
-WEBAPP_VERSION = "1.7.2"
+WEBAPP_VERSION = "1.7.3"
 
 # Application definition
 


### PR DESCRIPTION
We are swapping from Sendgrid to Marketo for email communications. This PR adds the Marketo email form.

![screen shot 2018-11-01 at 6 45 00 pm](https://user-images.githubusercontent.com/9206065/47884317-9ffb0b80-de06-11e8-8079-9b98fdd36a3c.png)


cc @Peter-Metz @MattHJensen 