### PR TITLE
Use AWS Container Registry instead of DockerHub

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,19 +2,19 @@ OSPC_ANACONDA_TOKEN := `cat ~/.ospc_anaconda_token`
 NEW_RELIC_TOKEN := `cat ~/.newrelic-$(MODE)`
 
 dist-build:
-        cd distributed && \
-        docker build -t distributed:$(TAG) ./ --build-arg PUF_TOKEN=$(OSPC_ANACONDA_TOKEN) && \
-        docker build --no-cache --build-arg TAG=$(TAG) -t flask:$(TAG) --file Dockerfile.flask ./ && \
-        docker build --no-cache --build-arg TAG=$(TAG) -t celery:$(TAG) --file Dockerfile.celery ./
+	cd distributed && \
+	docker build -t distributed:$(TAG) ./ --build-arg PUF_TOKEN=$(OSPC_ANACONDA_TOKEN) && \
+	docker build --no-cache --build-arg TAG=$(TAG) -t flask:$(TAG) --file Dockerfile.flask ./ && \
+	docker build --no-cache --build-arg TAG=$(TAG) -t celery:$(TAG) --file Dockerfile.celery ./
 
 dist-push:
-        cd distributed && \
-        docker tag distributed:$(TAG) $(AWS_ACCOUNT_ID).dkr.ecr.$(AWS_REGION).amazonaws.com/distributed:$(TAG) && \
-        docker tag flask:$(TAG) $(AWS_ACCOUNT_ID).dkr.ecr.$(AWS_REGION).amazonaws.com/flask:$(TAG) && \
-        docker tag celery:$(TAG) $(AWS_ACCOUNT_ID).dkr.ecr.$(AWS_REGION).amazonaws.com/celery:$(TAG) && \
-        docker push $(AWS_ACCOUNT_ID).dkr.ecr.$(AWS_REGION).amazonaws.com/distributed:$(TAG) && \
-        docker push $(AWS_ACCOUNT_ID).dkr.ecr.$(AWS_REGION).amazonaws.com/flask:$(TAG) && \
-        docker push $(AWS_ACCOUNT_ID).dkr.ecr.$(AWS_REGION).amazonaws.com/celery:$(TAG)
+	cd distributed && \
+	docker tag distributed:$(TAG) $(AWS_ACCOUNT_ID).dkr.ecr.$(AWS_REGION).amazonaws.com/distributed:$(TAG) && \
+	docker tag flask:$(TAG) $(AWS_ACCOUNT_ID).dkr.ecr.$(AWS_REGION).amazonaws.com/flask:$(TAG) && \
+	docker tag celery:$(TAG) $(AWS_ACCOUNT_ID).dkr.ecr.$(AWS_REGION).amazonaws.com/celery:$(TAG) && \
+	docker push $(AWS_ACCOUNT_ID).dkr.ecr.$(AWS_REGION).amazonaws.com/distributed:$(TAG) && \
+	docker push $(AWS_ACCOUNT_ID).dkr.ecr.$(AWS_REGION).amazonaws.com/flask:$(TAG) && \
+	docker push $(AWS_ACCOUNT_ID).dkr.ecr.$(AWS_REGION).amazonaws.com/celery:$(TAG)
 
 dist-test:
 	cd distributed && \

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -10,6 +10,7 @@ Release 1.7.4 on 2018-11-06
 - None
 
 **Minor Changes**
+- [#942](https://github.com/ospc-org/ospc.org/pull/939) -  Use AWS Container Registry instead of DockerHub #942 - Hank Doupe
 - [#939](https://github.com/ospc-org/ospc.org/pull/939) - Update to Tax-Calculator 0.22.2 - Hank Doupe
 
 **Bug Fixes**

--- a/distributed/Dockerfile.celery
+++ b/distributed/Dockerfile.celery
@@ -1,5 +1,5 @@
 ARG TAG
-FROM opensourcepolicycenter/distributed:$TAG
+FROM distributed:$TAG
 
 ENV CELERY_BROKER_URL redis://redis:6379/0
 ENV CELERY_RESULT_BACKEND redis://redis:6379/0

--- a/distributed/Dockerfile.flask
+++ b/distributed/Dockerfile.flask
@@ -1,5 +1,5 @@
 ARG TAG
-FROM opensourcepolicycenter/distributed:$TAG
+FROM distributed:$TAG
 
 LABEL build="flask" date="2018-06-13"
 

--- a/distributed/README.md
+++ b/distributed/README.md
@@ -1,0 +1,30 @@
+# Distributed deploy instructions
+
+1. Build and push images to AWS container registry
+    ```
+    export MODE= TAG= AWS_ACCOUNT_ID= AWS_REGION=
+    rm -rf PolicyBrain
+    git clone https://github.com/OpenSourcePolicyCenter/PolicyBrain
+    cd PolicyBrain
+    git fetch origin
+    git checkout -b $TAG $TAG
+
+    pushd .. && make dist-build -e TAG=$TAG && \
+        make dist-push -e TAG=$TAG && popd &&\
+    ```
+
+
+2. Pull distributed images to AWS server
+    ```
+    sudo docker-compose down
+    sudo docker-compose rm
+    docker system prune --all
+    sudo apt-get install awscli
+    sudo apt-get install python3-pip
+    pip3 install --upgrade awscli
+    aws configure
+    sudo $AWS_ACCOUNT_ID= $AWS_REGION=
+    sudo $(aws ecr get-login --region $AWS_REGION --no-include-email)
+    sudo REPO=$AWS_ACCOUNT_ID.dkr.ecr.$AWS_REGION.amazonaws.com TAG=$TAG
+    sudo docker-compose up -d
+    ```

--- a/distributed/README.md
+++ b/distributed/README.md
@@ -2,15 +2,14 @@
 
 1. Build and push images to AWS container registry
     ```
-    export MODE= TAG= AWS_ACCOUNT_ID= AWS_REGION=
+    export TAG= AWS_ACCOUNT_ID= AWS_REGION=
     rm -rf PolicyBrain
     git clone https://github.com/OpenSourcePolicyCenter/PolicyBrain
     cd PolicyBrain
     git fetch origin
     git checkout -b $TAG $TAG
 
-    pushd .. && make dist-build -e TAG=$TAG && \
-        make dist-push -e TAG=$TAG && popd &&\
+    make dist-build && make dist-push
     ```
 
 

--- a/distributed/docker-compose.yml
+++ b/distributed/docker-compose.yml
@@ -1,14 +1,14 @@
 version: '3'
 services:
   flask:
-    image: "opensourcepolicycenter/flask:${TAG}"
+    image: "${REPO}/flask:${TAG}"
     ports:
       - 5050:5050
     depends_on:
       - redis
       - celery
   celery:
-    image: "opensourcepolicycenter/celery:${TAG}"
+    image: "${REPO}/celery:${TAG}"
     depends_on:
       - redis
   redis:


### PR DESCRIPTION
This PR supersedes PR #932. I recently tested these changes and instructions when deploying v1.7.4_rc1. 